### PR TITLE
A3C-Doom fixed one-hot def to work with a_size

### DIFF
--- a/A3C-Doom.ipynb
+++ b/A3C-Doom.ipynb
@@ -227,7 +227,7 @@
     "        game.set_living_reward(-1)\n",
     "        game.set_mode(Mode.PLAYER)\n",
     "        game.init()\n",
-    "        self.actions = [[True,False,False],[False,True,False],[False,False,True]]\n",
+    "        self.actions = self.actions = np.identity(a_size,dtype=bool).tolist()\n",
     "        #End Doom set-up\n",
     "        self.env = game\n",
     "        \n",


### PR DESCRIPTION
Setting a_size to a new value would eventually create an error due to the hard coded(line 230) one-hot array of actions. Replaced with numpy identity using a_size and resolved to a list to match the original format.